### PR TITLE
07 user edit and revise header

### DIFF
--- a/app/javascript/mypage_dropdown.js
+++ b/app/javascript/mypage_dropdown.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("turbo:load", () => {
   let hideTimeout; // タイマーを管理する変数
 
   const dropdownContainer = document.getElementById("dropdown-container");

--- a/app/views/users/headers/_signed_in.html.erb
+++ b/app/views/users/headers/_signed_in.html.erb
@@ -12,7 +12,7 @@
         </button>
         <ul class="absolute right-0 w-56 origin-top-right rounded-md bg-blue-600 shadow-lg ring-1 ring-white/10" style= 'display: none;' id='dropdown-menu' >
           <li><span class="block px-4 py-2 text-sm text-gray-300"><%= current_user.name%><%= t('header.san') %></span></li>
-          <li><%= link_to t('header.account_detail'), '#', class: 'block px-4 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white' %></li>
+          <li><%= link_to t('header.account_detail'), edit_user_registration_path, class: 'block px-4 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white' %></li>
           <li><%= link_to t('header.logout'), destroy_user_session_path, data: {turbo_method: :delete }, class: 'block px-4 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white' %></li>
         </ul>
       </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,43 +1,48 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class='flex flex-col items-center justify-center   h-screen md:bg-gray-100'>
+  <div class='w-full md:w-1/2 md:rounded-lg md:shadow-lg bg-white p-20 text-gray-800'>
+    <h2 class='text-center text-2xl font-semibold mb-4'><%= t('devise.registrations.edit.title') %></h2>
+  
+    <div class='w-full flex-wrap whitespace-nowrap'>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
+        
+        <div class="mb-2">
+          <%= f.label :name %> :<br />
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'w-full ring rounded ring-gray-300 mb-2 p-1' %>
+        </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+        <div class="mb-2">
+          <%= f.label :email %> :<br />
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'w-full ring rounded ring-gray-300 mb-2 p-1' %>
+        </div>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <% end %>
+        <div class="mb-2">
+          <%= f.label :password %> : <br />
+          <span class='text-xs text-red-600'>* <%= t('devise.registrations.edit.leave_blank_if_you_don_t_want_to_change_it') %></span><br />
+          <% if @minimum_password_length %>
+            <span class='text-xs text-red-600'>* <%= t('devise.shared.minimum_password_length.other', count: @minimum_password_length) %></span>
+          <% end %><br />
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: 'w-full ring rounded ring-gray-300 mb-2 p-1' %>
+        </div>
+        <div class="mb-2">
+          <%= f.label :password_confirmation %>:<br />
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'w-full ring rounded ring-gray-300 mb-2 p-1' %>
+        </div>
+        <div class="mb-2">
+          <%= f.label :current_password %> :<br />
+          <span class='text-xs text-red-600'>* <%= t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes') %></span><br />
+          <%= f.password_field :current_password, autocomplete: "current-password", class: 'w-full ring rounded ring-gray-300 mb-2 p-1' %>
+        </div>
+        <div class="text-center mt-8">
+          <%= f.submit "Update", class: 'w-full border border-gray-400 hover:border-gray-500 px-4 py-1 rounded bg-blue-200 hover:bg-blue-300' %>
+        </div>
+      <% end %>
+      <h3>Cancel my account</h3>
+      <div><%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: 'w-full border border-gray-400 hover:border-gray-500 px-4 py-1 rounded bg-red-200 hover:bg-red-300' %></div>
+      <div class='mt-2 text-center hover:text-blue-800'><%= link_to "Back", :back %></div>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <div class='flex flex-col items-center justify-center h-screen md:bg-gray-100'>
   <div class='w-full md:w-1/2 md:rounded-lg md:shadow-lg bg-white p-20 text-gray-800'>
-    <h2 class='text-center text-2xl font-semibold mb-6'><%= t('devise.registrations.edit.title1') %></h2>
+    <h2 class='text-center text-2xl font-semibold mb-4'><%= t('devise.registrations.edit.title1') %></h2>
   
     <div class='w-full flex-wrap whitespace-nowrap'>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -40,8 +40,6 @@
           <%= f.submit "Update", class: 'w-full border border-gray-400 hover:border-gray-500 px-4 py-1 rounded bg-blue-200 hover:bg-blue-300' %>
         </div>
       <% end %>
-      <h3>Cancel my account</h3>
-      <div><%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: 'w-full border border-gray-400 hover:border-gray-500 px-4 py-1 rounded bg-red-200 hover:bg-red-300' %></div>
       <div class='mt-2 text-center hover:text-blue-800'><%= link_to "Back", :back %></div>
     </div>
   </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,6 +1,6 @@
-<div class='flex flex-col items-center justify-center   h-screen md:bg-gray-100'>
+<div class='flex flex-col items-center justify-center h-screen md:bg-gray-100'>
   <div class='w-full md:w-1/2 md:rounded-lg md:shadow-lg bg-white p-20 text-gray-800'>
-    <h2 class='text-center text-2xl font-semibold mb-4'><%= t('devise.registrations.edit.title') %></h2>
+    <h2 class='text-center text-2xl font-semibold mb-6'><%= t('devise.registrations.edit.title1') %></h2>
   
     <div class='w-full flex-wrap whitespace-nowrap'>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
@@ -37,10 +37,10 @@
           <%= f.password_field :current_password, autocomplete: "current-password", class: 'w-full ring rounded ring-gray-300 mb-2 p-1' %>
         </div>
         <div class="text-center mt-8">
-          <%= f.submit "Update", class: 'w-full border border-gray-400 hover:border-gray-500 px-4 py-1 rounded bg-blue-200 hover:bg-blue-300' %>
+          <%= f.submit t('devise.registrations.edit.update'), class: 'w-full border border-gray-400 hover:border-gray-500 px-4 py-1 rounded bg-blue-200 hover:bg-blue-300' %>
         </div>
       <% end %>
-      <div class='mt-2 text-center hover:text-blue-800'><%= link_to "Back", :back %></div>
+      <div class='mt-2 text-center hover:text-blue-800'><%= link_to t('devise.shared.links.back'), :back %></div>
     </div>
   </div>
 </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -94,10 +94,11 @@ ja:
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
+        title: アカウント情報変更
         are_you_sure: 本当によろしいですか？
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: '%{email} の確認待ち'
-        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        leave_blank_if_you_don_t_want_to_change_it: パスワードを変更しない場合は空欄のままにしてください
         title: "%{resource}編集"
         unhappy: 気に入りません
         update: 更新
@@ -129,7 +130,7 @@ ja:
         sign_in_with_provider: "%{provider}でログイン"
         sign_up: アカウント登録
       minimum_password_length:
-        other: "（英数 %{count} 文字以上）"
+        other: "英数 %{count} 文字以上で設定してください"
     unlocks:
       new:
         resend_unlock_instructions: アカウントのロック解除方法を再送する

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -94,14 +94,14 @@ ja:
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
-        title: アカウント情報変更
+        title1: アカウント情報編集
         are_you_sure: 本当によろしいですか？
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: '%{email} の確認待ち'
         leave_blank_if_you_don_t_want_to_change_it: パスワードを変更しない場合は空欄のままにしてください
         title: "%{resource}編集"
         unhappy: 気に入りません
-        update: 更新
+        update: 更新する
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
         title: アカウント新規作成


### PR DESCRIPTION
### 概要
- アカウント情報編集画面のレイアウト追加
- ヘッダーのdropdown機能修正

### 詳細
- アカウント情報編集画面のレイアウト追加しました
<img width="1470" height="956" alt="スクリーンショット 2025-08-21 17 04 07" src="https://github.com/user-attachments/assets/8f968b2c-395d-4234-8676-fdc676503158" />


- ヘッダーのドロップダウンメニューがリロードなしで動作するよう修正しました